### PR TITLE
Implemented proper handling by document_watcher

### DIFF
--- a/Docs/test_text_rag.txt
+++ b/Docs/test_text_rag.txt
@@ -1,8 +1,0 @@
-Spesific to Computer Architecture Course:
-
-The teacher name is Andreas Diavastos, any questions about the course should be addressed to him.
-The Midterm Exam for Computer Architecture is on 14/03/2025 5 pm at Drakos building, floor 2 room 201.
-The Final Exam for Computer Architecture is on 15/05/2025 2 pm at Andreas Themistokleous building, ground floor, room 1.
-The Course main book is Computer Architecture 6th edition by John Hennessy and David Patterson.  
-
-For any Platform issues, one should contact Konyk Yuriy 

--- a/Docs/test_text_rag.txt
+++ b/Docs/test_text_rag.txt
@@ -4,3 +4,5 @@ The teacher name is Andreas Diavastos, any questions about the course should be 
 The Midterm Exam for Computer Architecture is on 14/03/2025 5 pm at Drakos building, floor 2 room 201.
 The Final Exam for Computer Architecture is on 15/05/2025 2 pm at Andreas Themistokleous building, ground floor, room 1.
 The Course main book is Computer Architecture 6th edition by John Hennessy and David Patterson.  
+
+For any Platform issues, one should contact Konyk Yuriy 

--- a/src/chroma_gui.py
+++ b/src/chroma_gui.py
@@ -1,0 +1,109 @@
+import tkinter as tk
+from tkinter import ttk, scrolledtext
+import chromadb
+from chromadb.config import Settings
+import json
+
+class ChromaDBBrowser(tk.Tk):
+    def __init__(self):
+        super().__init__()
+
+        self.title("ChromaDB Browser")
+        self.geometry("1200x800")
+
+        # Initialize ChromaDB client
+        self.client = chromadb.PersistentClient(path="./chroma_db")
+
+        # Create main layout
+        self.create_widgets()
+        self.refresh_collections()
+
+    def create_widgets(self):
+        # Left panel for collections
+        left_frame = ttk.Frame(self)
+        left_frame.pack(side=tk.LEFT, fill=tk.Y, padx=5, pady=5)
+
+        ttk.Label(left_frame, text="Collections:").pack(anchor=tk.W)
+        self.collection_listbox = tk.Listbox(left_frame, width=30, height=20)
+        self.collection_listbox.pack(fill=tk.Y, expand=True)
+        self.collection_listbox.bind('<<ListboxSelect>>', self.on_collection_select)
+
+        refresh_btn = ttk.Button(left_frame, text="Refresh Collections", command=self.refresh_collections)
+        refresh_btn.pack(fill=tk.X, pady=5)
+
+        # Right panel for document details
+        right_frame = ttk.Frame(self)
+        right_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        # Documents list
+        doc_frame = ttk.Frame(right_frame)
+        doc_frame.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(doc_frame, text="Documents:").pack(anchor=tk.W)
+        self.doc_listbox = tk.Listbox(doc_frame, height=10)
+        self.doc_listbox.pack(fill=tk.X)
+        self.doc_listbox.bind('<<ListboxSelect>>', self.on_document_select)
+
+        # Document details
+        details_frame = ttk.Frame(right_frame)
+        details_frame.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
+
+        ttk.Label(details_frame, text="Document Details:").pack(anchor=tk.W)
+        self.details_text = scrolledtext.ScrolledText(details_frame, wrap=tk.WORD, height=20)
+        self.details_text.pack(fill=tk.BOTH, expand=True)
+
+    def refresh_collections(self):
+        self.collection_listbox.delete(0, tk.END)
+        collections = self.client.list_collections()
+        for collection in collections:
+            self.collection_listbox.insert(tk.END, collection)
+
+    def on_collection_select(self, event):
+        selection = self.collection_listbox.curselection()
+        if not selection:
+            return
+
+        collection_name = self.collection_listbox.get(selection[0])
+        collection = self.client.get_collection(collection_name)
+        
+        # Clear previous documents
+        self.doc_listbox.delete(0, tk.END)
+        self.details_text.delete('1.0', tk.END)
+
+        # Get all documents in the collection
+        try:
+            results = collection.get()
+            for i, doc_id in enumerate(results['ids']):
+                display_text = f"{doc_id[:8]}... - {results['documents'][i][:50]}..."
+                self.doc_listbox.insert(tk.END, display_text)
+                # Store the full data for later retrieval
+                self.doc_listbox.data = results
+        except Exception as e:
+            self.details_text.insert(tk.END, f"Error loading documents: {str(e)}")
+
+    def on_document_select(self, event):
+        selection = self.doc_listbox.curselection()
+        if not selection or not hasattr(self.doc_listbox, 'data'):
+            return
+
+        idx = selection[0]
+        results = self.doc_listbox.data
+
+        # Format document details
+        details = {
+            "ID": results['ids'][idx],
+            "Document": results['documents'][idx],
+            "Metadata": results['metadatas'][idx] if results['metadatas'] else {},
+            "Embeddings": results['embeddings'][idx] if results['embeddings'] else []
+        }
+
+        # Display formatted details
+        self.details_text.delete('1.0', tk.END)
+        self.details_text.insert(tk.END, json.dumps(details, indent=2))
+
+def main():
+    app = ChromaDBBrowser()
+    app.mainloop()
+
+if __name__ == "__main__":
+    main()

--- a/src/chroma_manager.py
+++ b/src/chroma_manager.py
@@ -91,6 +91,47 @@ class ChromaManager(IEmbeddingManager):
             
         return formatted_results
     
+    def delete_documents_by_metadata(self, metadata_key: str, metadata_value: Any) -> None:
+        """
+        Delete all documents that match the given metadata key-value pair.
+        
+        Args:
+            metadata_key (str): Metadata key to match
+            metadata_value (Any): Value to match for the given key
+        """
+        # Get all documents with matching metadata
+        results = self.collection.get(
+            where={metadata_key: metadata_value}
+        )
+        
+        if results["ids"]:
+            self.collection.delete(ids=results["ids"])
+            
+    def get_documents_by_metadata(self, metadata_key: str, metadata_value: Any) -> List[Dict[str, Any]]:
+        """
+        Get all documents that match the given metadata key-value pair.
+        
+        Args:
+            metadata_key (str): Metadata key to match
+            metadata_value (Any): Value to match for the given key
+            
+        Returns:
+            List[Dict[str, Any]]: List of matching documents with their metadata
+        """
+        results = self.collection.get(
+            where={metadata_key: metadata_value}
+        )
+        
+        formatted_results = []
+        for i in range(len(results["ids"])):
+            formatted_results.append({
+                'id': results["ids"][i],
+                'document': results["documents"][i],
+                'metadata': results["metadatas"][i]
+            })
+            
+        return formatted_results
+    
     def flush(self) -> None:
         """
         Delete all documents from the collection.

--- a/src/document_watcher.py
+++ b/src/document_watcher.py
@@ -4,10 +4,12 @@ from watchdog.events import FileSystemEventHandler
 import os
 from embedding_manager import EmbeddingManager
 from pdf_chunker import PdfChunker
+from text_chunker import TextChunker
 from interfaces import IChunker
-from typing import Optional
+from typing import Optional, Dict
 import logging
 import argparse
+from threading import Timer
 
 # Configure logging
 logging.basicConfig(
@@ -16,7 +18,7 @@ logging.basicConfig(
 )
 
 class DocumentHandler(FileSystemEventHandler):
-    def __init__(self, embedding_manager: EmbeddingManager, chunker: Optional[IChunker] = None, flush_database: bool = False):
+    def __init__(self, embedding_manager: EmbeddingManager, chunker: Optional[IChunker] = None):
         """
         Initialize document handler with EmbeddingManager.
         
@@ -24,49 +26,94 @@ class DocumentHandler(FileSystemEventHandler):
             embedding_manager (EmbeddingManager): Instance of EmbeddingManager for document processing
         """
         self.embedding_manager = embedding_manager
-        self.processed_files = set()  # Track processed files to avoid duplicates
-        self.chunker = chunker or PdfChunker()  # Use PdfChunker by default
-        if flush_database:
-            self.embedding_manager.flush_db()
+        self.pdf_chunker = chunker or PdfChunker()
+        self.text_chunker = TextChunker()
+        self.processing_timers: Dict[str, Timer] = {}
+        self.DEBOUNCE_SECONDS = 1  # Wait for 1 second of no events before processing
         
     def _is_supported_file(self, file_path: str) -> bool:
         """Check if the file type is supported."""
         supported_extensions = {'.txt', '.pdf', '.csv'}
         return os.path.splitext(file_path)[1].lower() in supported_extensions
+    
+    def _get_chunker_for_file(self, file_path: str) -> IChunker:
+        """Get appropriate chunker based on file type."""
+        file_extension = os.path.splitext(file_path)[1].lower()
+        if file_extension == '.pdf':
+            return self.pdf_chunker
+        else:
+            return self.text_chunker
+    
+    def _remove_file_chunks(self, file_path: str):
+        """Remove all chunks associated with a file."""
+        file_name = os.path.basename(file_path)
+        logging.info(f"Removing existing chunks for {file_name}")
+        self.embedding_manager.chroma_manager.delete_documents_by_metadata('source', file_name)
         
     def _process_file(self, file_path: str):
-        """Process a file using EmbeddingManager or PdfChunker for PDFs if enabled."""
+        """Process a file using EmbeddingManager."""
         try:
             if not self._is_supported_file(file_path):
                 logging.info(f"Skipping unsupported file: {file_path}")
                 return
-                
-            if file_path in self.processed_files:
-                logging.info(f"File already processed: {file_path}")
-                return
-                
+            
+            file_name = os.path.basename(file_path)
+            
+            # Always remove existing chunks first
+            self._remove_file_chunks(file_path)
+            
             logging.info(f"Processing file: {file_path}")
             
-            # Process the file using the appropriate chunker
-            doc_ids = self.embedding_manager.add_file(
-                file_path,
-                metadata={'source': os.path.basename(file_path)}
-            )
-            self.processed_files.add(file_path)
+            # Get chunks using appropriate chunker
+            chunker = self._get_chunker_for_file(file_path)
+            chunks = chunker.chunk_document(file_path)
+            
+            # Process each chunk
+            doc_ids = []
+            for chunk in chunks:
+                chunk_id = self.embedding_manager.add_file(
+                    file_path,
+                    metadata={
+                        'source': file_name
+                    },
+                    text_content=chunk.text
+                )
+                doc_ids.extend(chunk_id)
+            
             logging.info(f"Successfully processed {file_path}. Added {len(doc_ids)} chunks.")
             
         except Exception as e:
             logging.error(f"Error processing {file_path}: {str(e)}")
+    
+    def _debounced_process_file(self, file_path: str):
+        """Process file with debouncing to prevent duplicate processing."""
+        # Cancel any existing timer for this file
+        if file_path in self.processing_timers:
+            self.processing_timers[file_path].cancel()
+            
+        # Create new timer
+        timer = Timer(self.DEBOUNCE_SECONDS, self._process_file, args=[file_path])
+        self.processing_timers[file_path] = timer
+        timer.start()
 
     def on_created(self, event):
         """Handle file creation events."""
         if not event.is_directory:
-            self._process_file(event.src_path)
+            self._debounced_process_file(event.src_path)
 
     def on_modified(self, event):
         """Handle file modification events."""
         if not event.is_directory:
-            self._process_file(event.src_path)
+            self._debounced_process_file(event.src_path)
+    
+    def on_deleted(self, event):
+        """Handle file deletion events."""
+        if not event.is_directory:
+            # Cancel any pending processing
+            if event.src_path in self.processing_timers:
+                self.processing_timers[event.src_path].cancel()
+                del self.processing_timers[event.src_path]
+            self._remove_file_chunks(event.src_path)
 
 class DocumentWatcher:
     def __init__(self, watch_directory: str = "Docs", chunker: Optional[IChunker] = None, 
@@ -85,10 +132,14 @@ class DocumentWatcher:
         
         # Initialize managers and ensure collection exists
         self.embedding_manager = EmbeddingManager()
-        # Ensure collection exists by accessing it
-        _ = self.embedding_manager.chroma_manager.create_collection()
         
-        self.event_handler = DocumentHandler(self.embedding_manager, chunker, flush_database)
+        # Ensure collection exists and handle database flushing
+        _ = self.embedding_manager.chroma_manager.create_collection()
+        if flush_database:
+            logging.info("Flushing database...")
+            self.embedding_manager.flush_db()
+        
+        self.event_handler = DocumentHandler(self.embedding_manager, chunker)
         self.observer = Observer()
         
     def _list_existing_files(self):
@@ -96,7 +147,7 @@ class DocumentWatcher:
         if not os.path.exists(self.watch_directory):
             os.makedirs(self.watch_directory)
             logging.info(f"Created directory: {self.watch_directory}")
-            return
+            return [], []
             
         supported_files = []
         unsupported_files = []
@@ -134,6 +185,7 @@ class DocumentWatcher:
             logging.info("Embedding existing files...")
             for filename in supported_files:
                 file_path = os.path.join(self.watch_directory, filename)
+                # Process existing files directly without debouncing
                 self.event_handler._process_file(file_path)
         
     def start(self):
@@ -151,6 +203,9 @@ class DocumentWatcher:
                 time.sleep(1)
         except KeyboardInterrupt:
             self.observer.stop()
+            # Cancel any pending timers
+            for timer in self.event_handler.processing_timers.values():
+                timer.cancel()
             logging.info("Stopped watching directory")
         
         self.observer.join()


### PR DESCRIPTION
Document watcher now handles the following scenarios:

If file is created, it will be chunked and embedded.
If file is modified, the existing chunks with the filename will be removed, and all the chunks of the new file will be re-embedded.
If file is removed, all chunks with the filename will be removed. 

All updates are being tracked by the `source` field in metadata.

Renaming the file under the monitored directory is currently unsupported. 
Currently it doesn't remove the old chunks and creates duplicate embeddings with a different source metadata field.